### PR TITLE
Update config.plist

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1382,7 +1382,7 @@
 			<key>SystemMemoryStatus</key>
 			<string>Auto</string>
 			<key>SystemProductName</key>
-			<string>MacBookPro15,2</string>
+			<string>MacPro7,1</string>
 			<key>SystemSerialNumber</key>
 			<string>C02Z82ZUJHCC</string>
 			<key>SystemUUID</key>


### PR DESCRIPTION
is strange, but using as <string>MacPro7,1</string> the HDMI works perfectly.

I don't think it's ideal, but for me it's working 100%

now i can discard my usb-c adapter